### PR TITLE
feat!: declare TypeScript methods

### DIFF
--- a/$/defineDataProperty.ts
+++ b/$/defineDataProperty.ts
@@ -1,0 +1,17 @@
+/**
+ * Augments {@linkcode $} with `"defineDataProperty"`.
+ *
+ * @module
+ */
+
+import $ from "💰/$.ts";
+
+const value = Symbol("$.defineDataProperty");
+
+declare module "💰/$.ts" {
+  interface DollarSign {
+    defineDataProperty: typeof value;
+  }
+}
+
+Object.defineProperty($, "defineDataProperty", { value });

--- a/.tools/define.ts
+++ b/.tools/define.ts
@@ -53,18 +53,21 @@ async function createMethodFiles(target: string, name: string) {
     const data = `\
 import $ from "💰/$.ts";
 import "💰/$/${name}.ts";
-
-function value(this: ${self}) {
-  throw new Error("not yet implemented");
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface ${interfaceName} {
-    [$.${name}]: typeof value;
+    [$.${name}](): void;
   }
 }
 
-Object.defineProperty(${target}, $.${name}, { value });
+Object[$.defineDataProperty](
+  ${target},
+  $.${name},
+  function (this: ${self}) {
+    throw new Error("not yet implemented");
+  },
+);
 `;
     await Deno.writeTextFile(path, data, { createNew: true });
   }

--- a/Array/$.build.ts
+++ b/Array/$.build.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/build.ts";
-
-function value<T>(generate: () => Iterable<T> | ArrayLike<T>): T[] {
-  return Array.from(generate());
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface ArrayConstructor {
-    [$.build]: typeof value;
+    [$.build]<T>(generate: () => Iterable<T> | ArrayLike<T>): T[];
   }
 }
 
-Object.defineProperty(Array, $.build, { value });
+Object[$.defineDataProperty](
+  Array,
+  $.build,
+  function (generate) {
+    return Array.from(generate());
+  },
+);

--- a/AsyncIterator/prototype/$.toArray.ts
+++ b/AsyncIterator/prototype/$.toArray.ts
@@ -1,24 +1,27 @@
 import $ from "💰/$.ts";
 import "💰/$/toArray.ts";
+import "💰/Object/$.defineDataProperty.ts";
 
 import * as AsyncIterator from "💰/AsyncIterator.ts";
 
-async function value<T>(this: AsyncIterator<T>): Promise<T[]> {
-  const result: T[] = [];
-  for (
-    let { done, value } = await this.next();
-    !done;
-    ({ done, value } = await this.next())
-  ) {
-    result.push(value);
-  }
-  return result;
-}
-
 declare global {
   interface AsyncIterator<T> {
-    [$.toArray]: typeof value;
+    [$.toArray](): Promise<T[]>;
   }
 }
 
-Object.defineProperty(AsyncIterator.prototype, $.toArray, { value });
+Object[$.defineDataProperty](
+  AsyncIterator.prototype,
+  $.toArray,
+  async function <T>(this: AsyncIterator<T>) {
+    const result: T[] = [];
+    for (
+      let { done, value } = await this.next();
+      !done;
+      ({ done, value } = await this.next())
+    ) {
+      result.push(value);
+    }
+    return result;
+  },
+);

--- a/BigInt/$.ONE.ts
+++ b/BigInt/$.ONE.ts
@@ -1,12 +1,11 @@
 import $ from "💰/$.ts";
 import "💰/$/ONE.ts";
-
-const value = 1n as bigint;
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigIntConstructor {
-    readonly [$.ONE]: typeof value;
+    readonly [$.ONE]: bigint;
   }
 }
 
-Object.defineProperty(BigInt, $.ONE, { value });
+Object[$.defineDataProperty](BigInt, $.ONE, 1n, "read-only");

--- a/BigInt/$.ZERO.ts
+++ b/BigInt/$.ZERO.ts
@@ -1,12 +1,11 @@
 import $ from "💰/$.ts";
 import "💰/$/ZERO.ts";
-
-const value = 0n as bigint;
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigIntConstructor {
-    readonly [$.ZERO]: typeof value;
+    readonly [$.ZERO]: bigint;
   }
 }
 
-Object.defineProperty(BigInt, $.ZERO, { value });
+Object[$.defineDataProperty](BigInt, $.ZERO, 0n, "read-only");

--- a/BigInt/prototype/$.add.ts
+++ b/BigInt/prototype/$.add.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/add.ts";
-
-function value(this: bigint, other: bigint): bigint {
-  return this + other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.add]: typeof value;
+    [$.add](other: bigint): bigint;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.add, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.add,
+  function (this: bigint, other) {
+    return this + other;
+  },
+);

--- a/BigInt/prototype/$.compareTo.ts
+++ b/BigInt/prototype/$.compareTo.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/compareTo.ts";
-
-function value(this: bigint, other: bigint): number {
-  return Number(this - other);
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.compareTo]: typeof value;
+    [$.compareTo](other: bigint): number;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.compareTo, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.compareTo,
+  function (this: bigint, other) {
+    return Number(this - other);
+  },
+);

--- a/BigInt/prototype/$.dec.ts
+++ b/BigInt/prototype/$.dec.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/dec.ts";
-
-function value(this: bigint) {
-  return this - 1n;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.dec]: typeof value;
+    [$.dec](): bigint;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.dec, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.dec,
+  function(this: bigint) {
+    return this - 1n;
+  },
+);

--- a/BigInt/prototype/$.div.ts
+++ b/BigInt/prototype/$.div.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/div.ts";
-
-function value(this: bigint, other: bigint): bigint {
-  return this / other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.div]: typeof value;
+    [$.div](other: bigint): bigint;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.div, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.div,
+  function(this: bigint, other) {
+    return this / other;
+  },
+);

--- a/BigInt/prototype/$.inc.ts
+++ b/BigInt/prototype/$.inc.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/inc.ts";
-
-function value(this: bigint) {
-  return this + 1n;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.inc]: typeof value;
+    [$.inc](): bigint;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.inc, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.inc,
+  function(this: bigint) {
+    return this + 1n;
+  },
+);

--- a/BigInt/prototype/$.isNegative.ts
+++ b/BigInt/prototype/$.isNegative.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/isNegative.ts";
-
-function value(this: bigint) {
-  return this < 0n;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.isNegative]: typeof value;
+    [$.isNegative](): boolean;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.isNegative, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.isNegative,
+  function(this: bigint) {
+    return this < 0n;
+  },
+);

--- a/BigInt/prototype/$.isPositive.ts
+++ b/BigInt/prototype/$.isPositive.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/isPositive.ts";
-
-function value(this: bigint) {
-  return this > 0n;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.isPositive]: typeof value;
+    [$.isPositive](): boolean;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.isPositive, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.isPositive,
+  function(this: bigint) {
+    return this > 0n;
+  },
+);

--- a/BigInt/prototype/$.mod.ts
+++ b/BigInt/prototype/$.mod.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/mod.ts";
-
-function value(this: bigint, other: bigint): bigint {
-  return ((this % other) + other) % other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.mod]: typeof value;
+    [$.mod](other: bigint): bigint;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.mod, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.mod,
+  function(this: bigint, other) {
+    return ((this % other) + other) % other;
+  },
+);

--- a/BigInt/prototype/$.mul.ts
+++ b/BigInt/prototype/$.mul.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/mul.ts";
-
-function value(this: bigint, other: bigint): bigint {
-  return this * other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.mul]: typeof value;
+    [$.mul](other: bigint): bigint;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.mul, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.mul,
+  function(this: bigint, other) {
+    return this * other;
+  },
+);

--- a/BigInt/prototype/$.neg.ts
+++ b/BigInt/prototype/$.neg.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/neg.ts";
-
-function value(this: bigint) {
-  return -this;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.neg]: typeof value;
+    [$.neg](): bigint;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.neg, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.neg,
+  function(this: bigint) {
+    return -this;
+  },
+);

--- a/BigInt/prototype/$.pow.ts
+++ b/BigInt/prototype/$.pow.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/pow.ts";
-
-function value(this: bigint, other: bigint): bigint {
-  return this ** other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.pow]: typeof value;
+    [$.pow](other: bigint): bigint;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.pow, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.pow,
+  function(this: bigint, other) {
+    return this ** other;
+  },
+);

--- a/BigInt/prototype/$.rem.ts
+++ b/BigInt/prototype/$.rem.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/rem.ts";
-
-function value(this: bigint, other: bigint): bigint {
-  return this % other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.rem]: typeof value;
+    [$.rem](other: bigint): bigint;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.rem, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.rem,
+  function(this: bigint, other) {
+    return this % other;
+  },
+);

--- a/BigInt/prototype/$.requireNonzero.ts
+++ b/BigInt/prototype/$.requireNonzero.ts
@@ -1,15 +1,18 @@
 import $ from "💰/$.ts";
 import "💰/$/requireNonzero.ts";
-
-function value(this: bigint, message = "this is zero") {
-  if (this === 0n) throw new RangeError(message);
-  return this;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.requireNonzero]: typeof value;
+    [$.requireNonzero](message?: string): bigint;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.requireNonzero, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.requireNonzero,
+  function(this: bigint, message = "this is zero") {
+    if (this === 0n) throw new RangeError(message);
+    return this;
+  },
+);

--- a/BigInt/prototype/$.requireSafePrecision.ts
+++ b/BigInt/prototype/$.requireSafePrecision.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/requireSafePrecision.ts";
-
-function value(this: bigint) {
-  return this;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.requireSafePrecision]: typeof value;
+    [$.requireSafePrecision](message?: string): bigint;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.requireSafePrecision, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.requireSafePrecision,
+  function(this: bigint) {
+    return this;
+  },
+);

--- a/BigInt/prototype/$.sign.ts
+++ b/BigInt/prototype/$.sign.ts
@@ -1,15 +1,18 @@
 import $ from "💰/$.ts";
 import "💰/$/sign.ts";
-
-function value(this: bigint) {
-  if (this === 0n) return 0n;
-  return this < 0n ? -1n : 1n;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.sign]: typeof value;
+    [$.sign](): 0n | 1n | -1n;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.sign, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.sign,
+  function(this: bigint) {
+    if (this === 0n) return 0n;
+    return this < 0n ? -1n : 1n;
+  },
+);

--- a/BigInt/prototype/$.sub.ts
+++ b/BigInt/prototype/$.sub.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/sub.ts";
-
-function value(this: bigint, other: bigint): bigint {
-  return this - other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface BigInt {
-    [$.sub]: typeof value;
+    [$.sub](other: bigint): bigint;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.sub, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.sub,
+  function(this: bigint, other) {
+    return this - other;
+  },
+);

--- a/BigInt/prototype/$.through.test.ts
+++ b/BigInt/prototype/$.through.test.ts
@@ -31,7 +31,7 @@ Deno.test("3 through 7 (default step)", async (t) => {
 });
 
 Deno.test("3 to 7 step 1", async (t) => {
-  const progression = (3n)[$.through](7n, { step: 1n });
+  const progression = (3n)[$.through](7n, 1n);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -58,7 +58,7 @@ Deno.test("3 to 7 step 1", async (t) => {
 });
 
 Deno.test("3 to 7 step 2", async (t) => {
-  const progression = (3n)[$.through](7n, { step: 2n });
+  const progression = (3n)[$.through](7n, 2n);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -87,7 +87,7 @@ Deno.test("3 to 7 step 2", async (t) => {
 });
 
 Deno.test("3 through 7 step 3", async (t) => {
-  const progression = (3n)[$.through](7n, { step: 3n });
+  const progression = (3n)[$.through](7n, 3n);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -118,7 +118,7 @@ Deno.test("3 through 7 step 3", async (t) => {
 });
 
 Deno.test("3 through 7 step 4", async (t) => {
-  const progression = (3n)[$.through](7n, { step: 4n });
+  const progression = (3n)[$.through](7n, 4n);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -151,7 +151,7 @@ Deno.test("3 through 7 step 4", async (t) => {
 });
 
 Deno.test("3 through 7 step 5", async (t) => {
-  const progression = (3n)[$.through](7n, { step: 5n });
+  const progression = (3n)[$.through](7n, 5n);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {

--- a/BigInt/prototype/$.through.ts
+++ b/BigInt/prototype/$.through.ts
@@ -1,18 +1,20 @@
 import $ from "💰/$.ts";
 import "💰/$/through.ts";
+import "💰/Object/$.defineDataProperty.ts";
 
 import "💰/BigInt/Progression/deps.ts";
-
 import Progression from "💰/Progression.ts";
-
-function value(this: bigint, end: bigint, { step }: { step?: bigint } = {}) {
-  return new Progression(this, end, step);
-}
 
 declare global {
   interface BigInt {
-    [$.through]: typeof value;
+    [$.through](end: bigint, step?: bigint): Progression<bigint>;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.through, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.through,
+  function (this: bigint, end, step) {
+    return new Progression(this, end, step);
+  },
+);

--- a/BigInt/prototype/$.to.test.ts
+++ b/BigInt/prototype/$.to.test.ts
@@ -31,7 +31,7 @@ Deno.test("3 to 7 (default step)", async (t) => {
 });
 
 Deno.test("3 to 7 step 1", async (t) => {
-  const progression = (3n)[$.to](7n, { step: 1n });
+  const progression = (3n)[$.to](7n, 1n);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -58,7 +58,7 @@ Deno.test("3 to 7 step 1", async (t) => {
 });
 
 Deno.test("3 to 7 step 2", async (t) => {
-  const progression = (3n)[$.to](7n, { step: 2n });
+  const progression = (3n)[$.to](7n, 2n);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -87,7 +87,7 @@ Deno.test("3 to 7 step 2", async (t) => {
 });
 
 Deno.test("3 to 7 step 3", async (t) => {
-  const progression = (3n)[$.to](7n, { step: 3n });
+  const progression = (3n)[$.to](7n, 3n);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -118,7 +118,7 @@ Deno.test("3 to 7 step 3", async (t) => {
 });
 
 Deno.test("3 to 7 step 4", async (t) => {
-  const progression = (3n)[$.to](7n, { step: 4n });
+  const progression = (3n)[$.to](7n, 4n);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -151,7 +151,7 @@ Deno.test("3 to 7 step 4", async (t) => {
 });
 
 Deno.test("3 to 7 step 5", async (t) => {
-  const progression = (3n)[$.to](7n, { step: 5n });
+  const progression = (3n)[$.to](7n, 5n);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {

--- a/BigInt/prototype/$.to.ts
+++ b/BigInt/prototype/$.to.ts
@@ -1,18 +1,20 @@
 import $ from "💰/$.ts";
 import "💰/$/to.ts";
+import "💰/Object/$.defineDataProperty.ts";
 
 import "💰/BigInt/Progression/deps.ts";
-
 import Progression from "💰/Progression.ts";
-
-function value(this: bigint, end: bigint, { step }: { step?: bigint } = {}) {
-  return new Progression(this, end - 1n, step);
-}
 
 declare global {
   interface BigInt {
-    [$.to]: typeof value;
+    [$.to](end: bigint, step?: bigint): Progression<bigint>;
   }
 }
 
-Object.defineProperty(BigInt.prototype, $.to, { value });
+Object[$.defineDataProperty](
+  BigInt.prototype,
+  $.to,
+  function (this: bigint, end, step) {
+    return new Progression(this, end - 1n, step);
+  },
+);

--- a/Boolean/prototype/$.compareTo.ts
+++ b/Boolean/prototype/$.compareTo.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/compareTo.ts";
-
-function value(this: boolean, other: boolean): number {
-  return Number(this) - Number(other);
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Boolean {
-    [$.compareTo]: typeof value;
+    [$.compareTo](other: boolean): number;
   }
 }
 
-Object.defineProperty(Boolean.prototype, $.compareTo, { value });
+Object[$.defineDataProperty](
+  Boolean.prototype,
+  $.compareTo,
+  function (this: boolean, other) {
+    return Number(this) - Number(other);
+  },
+);

--- a/Date/prototype/$.compareTo.ts
+++ b/Date/prototype/$.compareTo.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/compareTo.ts";
-
-function value(this: Date, other: Date): number {
-  return this.valueOf() - other.valueOf();
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Date {
-    [$.compareTo]: typeof value;
+    [$.compareTo](other: Date): number;
   }
 }
 
-Object.defineProperty(Date.prototype, $.compareTo, { value });
+Object[$.defineDataProperty](
+  Date.prototype,
+  $.compareTo,
+  function value(this: Date, other) {
+    return this.valueOf() - other.valueOf();
+  },
+);

--- a/Iterator/prototype/$.toArray.ts
+++ b/Iterator/prototype/$.toArray.ts
@@ -1,24 +1,27 @@
 import $ from "💰/$.ts";
 import "💰/$/toArray.ts";
+import "💰/Object/$.defineDataProperty.ts";
 
 import * as Iterator from "💰/Iterator.ts";
 
-function value<T>(this: Iterator<T>): T[] {
-  const result: T[] = [];
-  for (
-    let { done, value } = this.next();
-    !done;
-    ({ done, value } = this.next())
-  ) {
-    result.push(value);
-  }
-  return result;
-}
-
 declare global {
   interface Iterator<T> {
-    [$.toArray]: typeof value;
+    [$.toArray](): T[];
   }
 }
 
-Object.defineProperty(Iterator.prototype, $.toArray, { value });
+Object[$.defineDataProperty](
+  Iterator.prototype,
+  $.toArray,
+  function value<T>(this: Iterator<T>) {
+    const result: T[] = [];
+    for (
+      let { done, value } = this.next();
+      !done;
+      ({ done, value } = this.next())
+    ) {
+      result.push(value);
+    }
+    return result;
+  },
+);

--- a/Iterator/prototype/$.toAsync.ts
+++ b/Iterator/prototype/$.toAsync.ts
@@ -1,17 +1,20 @@
 import $ from "💰/$.ts";
 import "💰/$/toAsync.ts";
+import "💰/Object/$.defineDataProperty.ts";
 
 import * as AsyncIterator from "💰/AsyncIterator.ts";
 import * as Iterator from "💰/Iterator.ts";
 
-function value<T>(this: Iterator<T>): AsyncIterableIterator<T> {
-  return AsyncIterator.from({ next: () => Promise.resolve(this.next()) });
-}
-
 declare global {
   interface Iterator<T> {
-    [$.toAsync]: typeof value;
+    [$.toAsync](): AsyncIterableIterator<T>;
   }
 }
 
-Object.defineProperty(Iterator.prototype, $.toAsync, { value });
+Object[$.defineDataProperty](
+  Iterator.prototype,
+  $.toAsync,
+  function value<T>(this: Iterator<T>) {
+    return AsyncIterator.from({ next: () => Promise.resolve(this.next()) });
+  },
+);

--- a/Map/$.build.ts
+++ b/Map/$.build.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/build.ts";
-
-function value<K, V>(generate: () => Iterable<readonly [K, V]>): Map<K, V> {
-  return new Map(generate());
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface MapConstructor {
-    [$.build]: typeof value;
+    [$.build]<K, V>(generate: () => Iterable<readonly [K, V]>): Map<K, V>;
   }
 }
 
-Object.defineProperty(Map, $.build, { value });
+Object[$.defineDataProperty](
+  Map,
+  $.build,
+  function value<K, V>(generate: () => Iterable<readonly [K, V]>) {
+    return new Map(generate());
+  },
+);

--- a/Number/$.ONE.ts
+++ b/Number/$.ONE.ts
@@ -1,12 +1,11 @@
 import $ from "💰/$.ts";
 import "💰/$/ONE.ts";
-
-const value = 1 as number;
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface NumberConstructor {
-    readonly [$.ONE]: typeof value;
+    readonly [$.ONE]: number;
   }
 }
 
-Object.defineProperty(Number, $.ONE, { value });
+Object[$.defineDataProperty](Number, $.ONE, 1, "read-only");

--- a/Number/$.ZERO.ts
+++ b/Number/$.ZERO.ts
@@ -1,12 +1,11 @@
 import $ from "💰/$.ts";
 import "💰/$/ZERO.ts";
-
-const value = 0 as number;
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface NumberConstructor {
-    readonly [$.ZERO]: typeof value;
+    readonly [$.ZERO]: number;
   }
 }
 
-Object.defineProperty(Number, $.ZERO, { value });
+Object[$.defineDataProperty](Number, $.ZERO, 0, "read-only");

--- a/Number/prototype/$.add.ts
+++ b/Number/prototype/$.add.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/add.ts";
-
-function value(this: number, other: number): number {
-  return this + other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.add]: typeof value;
+    [$.add](other: number): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.add, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.add,
+  function value(this: number, other) {
+    return this + other;
+  },
+);

--- a/Number/prototype/$.compareTo.ts
+++ b/Number/prototype/$.compareTo.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/compareTo.ts";
-
-function value(this: number, other: number): number {
-  return this === other ? 0 : this - other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.compareTo]: typeof value;
+    [$.compareTo](other: number): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.compareTo, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.compareTo,
+  function value(this: number, other) {
+    return this === other ? 0 : this - other;
+  },
+);

--- a/Number/prototype/$.dec.ts
+++ b/Number/prototype/$.dec.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/dec.ts";
-
-function value(this: number) {
-  return this - 1;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.dec]: typeof value;
+    [$.dec](): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.dec, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.dec,
+  function value(this: number) {
+    return this - 1;
+  },
+);

--- a/Number/prototype/$.div.ts
+++ b/Number/prototype/$.div.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/div.ts";
-
-function value(this: number, other: number): number {
-  return this / other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.div]: typeof value;
+    [$.div](other: number): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.div, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.div,
+  function value(this: number, other) {
+    return this / other;
+  },
+);

--- a/Number/prototype/$.inc.ts
+++ b/Number/prototype/$.inc.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/inc.ts";
-
-function value(this: number) {
-  return this + 1;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.inc]: typeof value;
+    [$.inc](): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.inc, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.inc,
+  function value(this: number) {
+    return this + 1;
+  },
+);

--- a/Number/prototype/$.isInteger.ts
+++ b/Number/prototype/$.isInteger.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/isInteger.ts";
-
-function value(this: number) {
-  return Number.isInteger(this);
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.isInteger]: typeof value;
+    [$.isInteger](): boolean;
   }
 }
 
-Object.defineProperty(Number.prototype, $.isInteger, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.isInteger,
+  function value(this: number) {
+    return Number.isInteger(this);
+  },
+);

--- a/Number/prototype/$.isNegative.ts
+++ b/Number/prototype/$.isNegative.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/isNegative.ts";
-
-function value(this: number) {
-  return Object.is(this, -0) || this < 0;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.isNegative]: typeof value;
+    [$.isNegative](): boolean;
   }
 }
 
-Object.defineProperty(Number.prototype, $.isNegative, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.isNegative,
+  function value(this: number) {
+    return Object.is(this, -0) || this < 0;
+  },
+);

--- a/Number/prototype/$.isPositive.ts
+++ b/Number/prototype/$.isPositive.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/isPositive.ts";
-
-function value(this: number) {
-  return Object.is(this, 0) || this > 0;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.isPositive]: typeof value;
+    [$.isPositive](): boolean;
   }
 }
 
-Object.defineProperty(Number.prototype, $.isPositive, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.isPositive,
+  function value(this: number) {
+    return Object.is(this, 0) || this > 0;
+  },
+);

--- a/Number/prototype/$.mod.ts
+++ b/Number/prototype/$.mod.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/mod.ts";
-
-function value(this: number, other: number): number {
-  return ((this % other) + other) % other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.mod]: typeof value;
+    [$.mod](other: number): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.mod, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.mod,
+  function value(this: number, other) {
+    return ((this % other) + other) % other;
+  },
+);

--- a/Number/prototype/$.mul.ts
+++ b/Number/prototype/$.mul.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/mul.ts";
-
-function value(this: number, other: number): number {
-  return this * other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.mul]: typeof value;
+    [$.mul](other: number): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.mul, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.mul,
+  function value(this: number, other) {
+    return this * other;
+  },
+);

--- a/Number/prototype/$.neg.ts
+++ b/Number/prototype/$.neg.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/neg.ts";
-
-function value(this: number) {
-  return -this;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.neg]: typeof value;
+    [$.neg](): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.neg, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.neg,
+  function value(this: number) {
+    return -this;
+  },
+);

--- a/Number/prototype/$.pow.ts
+++ b/Number/prototype/$.pow.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/pow.ts";
-
-function value(this: number, other: number): number {
-  return this ** other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.pow]: typeof value;
+    [$.pow](other: number): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.pow, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.pow,
+  function value(this: number, other) {
+    return this ** other;
+  },
+);

--- a/Number/prototype/$.rem.ts
+++ b/Number/prototype/$.rem.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/rem.ts";
-
-function value(this: number, other: number): number {
-  return this % other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.rem]: typeof value;
+    [$.rem](other: number): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.rem, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.rem,
+  function value(this: number, other) {
+    return this % other;
+  },
+);

--- a/Number/prototype/$.requireNonzero.ts
+++ b/Number/prototype/$.requireNonzero.ts
@@ -1,15 +1,18 @@
 import $ from "💰/$.ts";
 import "💰/$/requireNonzero.ts";
-
-function value(this: number, message = "this is zero") {
-  if (this === 0) throw new RangeError(message);
-  return this;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.requireNonzero]: typeof value;
+    [$.requireNonzero](message?: string): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.requireNonzero, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.requireNonzero,
+  function value(this: number, message = "this is zero") {
+    if (this === 0) throw new RangeError(message);
+    return this;
+  },
+);

--- a/Number/prototype/$.requireSafeInteger.ts
+++ b/Number/prototype/$.requireSafeInteger.ts
@@ -1,15 +1,18 @@
 import $ from "💰/$.ts";
 import "💰/$/requireSafeInteger.ts";
-
-function value(this: number, message = `${this} is not a safe integer`) {
-  if (Number.isSafeInteger(this)) return this;
-  throw new RangeError(message);
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.requireSafeInteger]: typeof value;
+    [$.requireSafeInteger](message?: string): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.requireSafeInteger, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.requireSafeInteger,
+  function value(this: number, message = `${this} is not a safe integer`) {
+    if (Number.isSafeInteger(this)) return this;
+    throw new RangeError(message);
+  },
+);

--- a/Number/prototype/$.requireSafePrecision.ts
+++ b/Number/prototype/$.requireSafePrecision.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/requireSafePrecision.ts";
+import "💰/Object/$.defineDataProperty.ts";
 
 import "💰/Number/prototype/$.requireSafeInteger.ts";
 
-const value = Number.prototype[$.requireSafeInteger];
-
 declare global {
   interface Number {
-    [$.requireSafePrecision]: typeof value;
+    [$.requireSafePrecision](message?: string): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.requireSafePrecision, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.requireSafePrecision,
+  Number.prototype[$.requireSafeInteger],
+);

--- a/Number/prototype/$.sign.ts
+++ b/Number/prototype/$.sign.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/sign.ts";
-
-function value(this: number) {
-  return Math.sign(this);
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.sign]: typeof value;
+    [$.sign](): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.sign, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.sign,
+  function value(this: number) {
+    return Math.sign(this);
+  },
+);

--- a/Number/prototype/$.sub.ts
+++ b/Number/prototype/$.sub.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/sub.ts";
-
-function value(this: number, other: number): number {
-  return this - other;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Number {
-    [$.sub]: typeof value;
+    [$.sub](other: number): number;
   }
 }
 
-Object.defineProperty(Number.prototype, $.sub, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.sub,
+  function value(this: number, other) {
+    return this - other;
+  },
+);

--- a/Number/prototype/$.through.test.ts
+++ b/Number/prototype/$.through.test.ts
@@ -31,7 +31,7 @@ Deno.test("3 through 7 (default step)", async (t) => {
 });
 
 Deno.test("3 to 7 step 1", async (t) => {
-  const progression = (3)[$.through](7, { step: 1 });
+  const progression = (3)[$.through](7, 1);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -58,7 +58,7 @@ Deno.test("3 to 7 step 1", async (t) => {
 });
 
 Deno.test("3 to 7 step 2", async (t) => {
-  const progression = (3)[$.through](7, { step: 2 });
+  const progression = (3)[$.through](7, 2);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -87,7 +87,7 @@ Deno.test("3 to 7 step 2", async (t) => {
 });
 
 Deno.test("3 through 7 step 3", async (t) => {
-  const progression = (3)[$.through](7, { step: 3 });
+  const progression = (3)[$.through](7, 3);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -118,7 +118,7 @@ Deno.test("3 through 7 step 3", async (t) => {
 });
 
 Deno.test("3 through 7 step 4", async (t) => {
-  const progression = (3)[$.through](7, { step: 4 });
+  const progression = (3)[$.through](7, 4);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -151,7 +151,7 @@ Deno.test("3 through 7 step 4", async (t) => {
 });
 
 Deno.test("3 through 7 step 5", async (t) => {
-  const progression = (3)[$.through](7, { step: 5 });
+  const progression = (3)[$.through](7, 5);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -197,7 +197,7 @@ Deno.test("constructor limits", () => {
     "end must have safe precision",
   );
   assertThrows(
-    () => (1)[$.through](10, { step: Number.MIN_VALUE }),
+    () => (1)[$.through](10, Number.MIN_VALUE),
     RangeError,
     "step must have safe precision",
   );

--- a/Number/prototype/$.through.ts
+++ b/Number/prototype/$.through.ts
@@ -1,18 +1,20 @@
 import $ from "💰/$.ts";
 import "💰/$/through.ts";
+import "💰/Object/$.defineDataProperty.ts";
 
 import "💰/Number/Progression/deps.ts";
-
 import Progression from "💰/Progression.ts";
-
-function value(this: number, end: number, { step }: { step?: number } = {}) {
-  return new Progression(this, end, step);
-}
 
 declare global {
   interface Number {
-    [$.through]: typeof value;
+    [$.through](end: number, step?: number): Progression<number>;
   }
 }
 
-Object.defineProperty(Number.prototype, $.through, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.through,
+  function value(this: number, end, step) {
+    return new Progression(this, end, step);
+  },
+);

--- a/Number/prototype/$.to.test.ts
+++ b/Number/prototype/$.to.test.ts
@@ -31,7 +31,7 @@ Deno.test("3 to 7 (default step)", async (t) => {
 });
 
 Deno.test("3 to 7 step 1", async (t) => {
-  const progression = (3)[$.to](7, { step: 1 });
+  const progression = (3)[$.to](7, 1);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -58,7 +58,7 @@ Deno.test("3 to 7 step 1", async (t) => {
 });
 
 Deno.test("3 to 7 step 2", async (t) => {
-  const progression = (3)[$.to](7, { step: 2 });
+  const progression = (3)[$.to](7, 2);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -87,7 +87,7 @@ Deno.test("3 to 7 step 2", async (t) => {
 });
 
 Deno.test("3 to 7 step 3", async (t) => {
-  const progression = (3)[$.to](7, { step: 3 });
+  const progression = (3)[$.to](7, 3);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -118,7 +118,7 @@ Deno.test("3 to 7 step 3", async (t) => {
 });
 
 Deno.test("3 to 7 step 4", async (t) => {
-  const progression = (3)[$.to](7, { step: 4 });
+  const progression = (3)[$.to](7, 4);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -151,7 +151,7 @@ Deno.test("3 to 7 step 4", async (t) => {
 });
 
 Deno.test("3 to 7 step 5", async (t) => {
-  const progression = (3)[$.to](7, { step: 5 });
+  const progression = (3)[$.to](7, 5);
 
   await t.step("has", async (t) => {
     function expect(expected: boolean) {
@@ -197,7 +197,7 @@ Deno.test("constructor limits", () => {
     "end must have safe precision",
   );
   assertThrows(
-    () => (1)[$.to](10, { step: Number.MIN_VALUE }),
+    () => (1)[$.to](10, Number.MIN_VALUE),
     RangeError,
     "step must have safe precision",
   );

--- a/Number/prototype/$.to.ts
+++ b/Number/prototype/$.to.ts
@@ -1,18 +1,20 @@
 import $ from "💰/$.ts";
 import "💰/$/to.ts";
+import "💰/Object/$.defineDataProperty.ts";
 
 import "💰/Number/Progression/deps.ts";
-
 import Progression from "💰/Progression.ts";
-
-function value(this: number, end: number, { step }: { step?: number } = {}) {
-  return new Progression(this, end - 1, step);
-}
 
 declare global {
   interface Number {
-    [$.to]: typeof value;
+    [$.to](end: number, step?: number): Progression<number>;
   }
 }
 
-Object.defineProperty(Number.prototype, $.to, { value });
+Object[$.defineDataProperty](
+  Number.prototype,
+  $.to,
+  function value(this: number, end, step) {
+    return new Progression(this, end - 1, step);
+  },
+);

--- a/Object/$.defineDataProperty.test.ts
+++ b/Object/$.defineDataProperty.test.ts
@@ -1,0 +1,57 @@
+import $ from "💰/$.ts";
+import "💰/Object/$.defineDataProperty.ts";
+
+import {
+  assertEquals,
+  assertObjectMatch,
+  assertThrows,
+} from "std/testing/asserts.ts";
+
+const writableTestKey = Symbol();
+
+declare global {
+  interface Object {
+    [writableTestKey](): unknown;
+  }
+}
+
+Deno.test("configurable/writable", () => {
+  Object[$.defineDataProperty](Object.prototype, writableTestKey, () => 42);
+  assertEquals(({})[writableTestKey](), 42);
+  assertObjectMatch(
+    Object.getOwnPropertyDescriptor(Object.prototype, writableTestKey)!,
+    {
+      configurable: true,
+      enumerable: false,
+      writable: true,
+    },
+  );
+
+  Object.defineProperty(Object.prototype, writableTestKey, { value: () => 0 });
+  assertEquals(({})[writableTestKey](), 0);
+});
+
+const readonlyTestKey = Symbol();
+
+declare global {
+  interface ObjectConstructor {
+    [readonlyTestKey]: unknown;
+  }
+}
+
+Deno.test("read-only", () => {
+  Object[$.defineDataProperty](Object, readonlyTestKey, 126, "read-only");
+  assertEquals(Object[readonlyTestKey], 126);
+  assertObjectMatch(
+    Object.getOwnPropertyDescriptor(Object, readonlyTestKey)!,
+    {
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    },
+  );
+
+  assertThrows(() =>
+    Object.defineProperty(Object, readonlyTestKey, { value: 0 })
+  );
+});

--- a/Object/$.defineDataProperty.ts
+++ b/Object/$.defineDataProperty.ts
@@ -1,0 +1,35 @@
+import $ from "💰/$.ts";
+import "💰/$/defineDataProperty.ts";
+
+declare global {
+  interface ObjectConstructor {
+    [$.defineDataProperty]<T, K extends keyof T>(
+      target: T,
+      propertyKey: K,
+      value: T[K],
+      variant?: "read-only",
+    ): T;
+  }
+}
+
+const readonlyDescriptor = Object.create(null);
+
+const writableDescriptor = Object.create(null);
+writableDescriptor.configurable = true;
+writableDescriptor.enumerable = false;
+writableDescriptor.writable = true;
+
+function defineDataProperty<T, K extends keyof T>(
+  target: T,
+  propertyKey: K,
+  value: T[K],
+  variant?: "read-only",
+): T {
+  const descriptor = variant === "read-only"
+    ? readonlyDescriptor
+    : writableDescriptor;
+  descriptor.value = value;
+  return Object.defineProperty(target, propertyKey, descriptor);
+}
+
+defineDataProperty(Object, $.defineDataProperty, defineDataProperty);

--- a/Object/prototype/$.also.ts
+++ b/Object/prototype/$.also.ts
@@ -29,45 +29,51 @@
 
 import $ from "💰/$.ts";
 import "💰/$/also.ts";
-
-/**
- * Call some function on a value as its argument and then continue with the same value.
- *
- * Useful for side operations (e.g. inserting logging statements within a chain of operations).
- *
- * @example
- *
- * ```ts
- * import $ from "💰/$.ts";
- * import "💰/Object/prototype/$.also.ts";
- *
- * function getId() {
- *   return crypto.randomUUID()[$.also]((id) => console.debug("generated id:", id));
- * }
- * ```
- *
- * instead of
- *
- * ```ts
- * function getId() {
- *   const id = crypto.randomUUID();
- *   console.debug("generated id:", id);
- *   return id;
- * }
- * ```
- */
-function value<T extends NonNullable<unknown>>(
-  this: T,
-  action: (value: T) => void,
-): T {
-  action(this);
-  return this;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Object {
-    [$.also]: typeof value;
+    /**
+     * Call some function on a value as its argument and then continue with the same value.
+     *
+     * Useful for side operations (e.g. inserting logging statements within a chain of operations).
+     *
+     * @example
+     *
+     * ```ts
+     * import $ from "💰/$.ts";
+     * import "💰/Object/prototype/$.also.ts";
+     *
+     * function getId() {
+     *   return crypto.randomUUID()[$.also]((id) => console.debug("generated id:", id));
+     * }
+     * ```
+     *
+     * instead of
+     *
+     * ```ts
+     * function getId() {
+     *   const id = crypto.randomUUID();
+     *   console.debug("generated id:", id);
+     *   return id;
+     * }
+     * ```
+     */
+    [$.also]<T extends NonNullable<unknown>>(
+      this: T,
+      action: (value: T) => void,
+    ): T;
   }
 }
 
-Object.defineProperty(Object.prototype, $.also, { value });
+Object[$.defineDataProperty](
+  Object.prototype,
+  $.also,
+  function value<T extends NonNullable<unknown>>(
+    this: T,
+    action: (value: T) => void,
+  ) {
+    action(this);
+    return this;
+  },
+);

--- a/Object/prototype/$.is.ts
+++ b/Object/prototype/$.is.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/is.ts";
-
-function value<T extends NonNullable<unknown>>(this: T, that: T) {
-  return Object.is(this, that);
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Object {
-    [$.is]: typeof value;
+    [$.is]<T extends NonNullable<unknown>>(this: T, that: T): boolean;
   }
 }
 
-Object.defineProperty(Object.prototype, $.is, { value });
+Object[$.defineDataProperty](
+  Object.prototype,
+  $.is,
+  function value<T extends NonNullable<unknown>>(this: T, that: T) {
+    return Object.is(this, that);
+  },
+);

--- a/Object/prototype/$.let.ts
+++ b/Object/prototype/$.let.ts
@@ -28,43 +28,49 @@
 
 import $ from "💰/$.ts";
 import "💰/$/let.ts";
-
-/**
- * Call some function on a value as its argument and then continue with the return value.
- *
- * Useful for transforming some value—especially in conjunction with [optional chaining (?.)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining).
- *
- * @example
- *
- * ```ts
- * import $ from "💰/$.ts";
- * import "💰/Object/prototype/$.let.ts";
- *
- * function getSpecialRandomNumber() {
- *   return Math.random()[$.let]((n) => n < 0.5 ? n : n * 10);
- * }
- * ```
- *
- * instead of
- *
- * ```ts
- * function getSpecialRandomNumber() {
- *   const n = Math.random();
- *   return n < 0.5 ? n : n * 10;
- * }
- * ```
- */
-function value<T extends NonNullable<unknown>, R>(
-  this: T,
-  transform: (value: T) => R,
-): R {
-  return transform(this);
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface Object {
-    [$.let]: typeof value;
+    /**
+     * Call some function on a value as its argument and then continue with the return value.
+     *
+     * Useful for transforming some value—especially in conjunction with [optional chaining (?.)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining).
+     *
+     * @example
+     *
+     * ```ts
+     * import $ from "💰/$.ts";
+     * import "💰/Object/prototype/$.let.ts";
+     *
+     * function getSpecialRandomNumber() {
+     *   return Math.random()[$.let]((n) => n < 0.5 ? n : n * 10);
+     * }
+     * ```
+     *
+     * instead of
+     *
+     * ```ts
+     * function getSpecialRandomNumber() {
+     *   const n = Math.random();
+     *   return n < 0.5 ? n : n * 10;
+     * }
+     * ```
+     */
+    [$.let]<T extends NonNullable<unknown>, R>(
+      this: T,
+      transform: (value: T) => R,
+    ): R;
   }
 }
 
-Object.defineProperty(Object.prototype, $.let, { value });
+Object[$.defineDataProperty](
+  Object.prototype,
+  $.let,
+  function value<T extends NonNullable<unknown>, R>(
+    this: T,
+    transform: (value: T) => R,
+  ) {
+    return transform(this);
+  },
+);

--- a/Set/$.build.ts
+++ b/Set/$.build.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/build.ts";
-
-function value<T>(generate: () => Iterable<T>): Set<T> {
-  return new Set(generate());
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface SetConstructor {
-    [$.build]: typeof value;
+    [$.build]<T>(generate: () => Iterable<T>): Set<T>;
   }
 }
 
-Object.defineProperty(Set, $.build, { value });
+Object[$.defineDataProperty](
+  Set,
+  $.build,
+  function value(generate) {
+    return new Set(generate());
+  },
+);

--- a/String/$.build.ts
+++ b/String/$.build.ts
@@ -1,16 +1,19 @@
 import $ from "💰/$.ts";
 import "💰/$/build.ts";
-
-function value<T>(generate: () => Iterable<T>): string {
-  let result = "";
-  for (const value of generate()) result += value;
-  return result;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface StringConstructor {
-    [$.build]: typeof value;
+    [$.build]<T>(generate: () => Iterable<T>): string;
   }
 }
 
-Object.defineProperty(String, $.build, { value });
+Object[$.defineDataProperty](
+  String,
+  $.build,
+  function value(generate) {
+    let result = "";
+    for (const value of generate()) result += value;
+    return result;
+  },
+);

--- a/String/prototype/$.compareTo.ts
+++ b/String/prototype/$.compareTo.ts
@@ -1,14 +1,17 @@
 import $ from "💰/$.ts";
 import "💰/$/compareTo.ts";
-
-function value(this: string, other: string): number {
-  return this === other ? 0 : this < other ? -1 : 1;
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface String {
-    [$.compareTo]: typeof value;
+    [$.compareTo](other: string): number;
   }
 }
 
-Object.defineProperty(String.prototype, $.compareTo, { value });
+Object[$.defineDataProperty](
+  String.prototype,
+  $.compareTo,
+  function value(this: string, other) {
+    return this === other ? 0 : this < other ? -1 : 1;
+  },
+);

--- a/String/prototype/$.lineIterator.ts
+++ b/String/prototype/$.lineIterator.ts
@@ -1,39 +1,42 @@
 import $ from "💰/$.ts";
 import "💰/$/lineIterator.ts";
+import "💰/Object/$.defineDataProperty.ts";
 
 import * as Iterator from "💰/Iterator.ts";
 
-function value(this: string): IterableIterator<string> {
-  const { length } = this;
-  let start = 0;
-  const next = (): IteratorResult<string> => {
-    if (start >= length) return { value: undefined, done: true };
-    for (let end = start; end < length; end++) {
-      switch (this[end]) {
-        case "\n": {
-          const value = this.slice(start, end);
-          start = end + 1;
-          return { value, done: false };
-        }
-        case "\r": {
-          const value = this.slice(start, end);
-          if (this[end + 1] === "\n") end++;
-          start = end + 1;
-          return { value, done: false };
-        }
-      }
-    }
-    const value = this.slice(start, length);
-    start = length;
-    return { value, done: false };
-  };
-  return Iterator.from({ next });
-}
-
 declare global {
   interface String {
-    [$.lineIterator]: typeof value;
+    [$.lineIterator](): IterableIterator<string>;
   }
 }
 
-Object.defineProperty(String.prototype, $.lineIterator, { value });
+Object[$.defineDataProperty](
+  String.prototype,
+  $.lineIterator,
+  function value(this: string) {
+    const { length } = this;
+    let start = 0;
+    const next = (): IteratorResult<string> => {
+      if (start >= length) return { value: undefined, done: true };
+      for (let end = start; end < length; end++) {
+        switch (this[end]) {
+          case "\n": {
+            const value = this.slice(start, end);
+            start = end + 1;
+            return { value, done: false };
+          }
+          case "\r": {
+            const value = this.slice(start, end);
+            if (this[end + 1] === "\n") end++;
+            start = end + 1;
+            return { value, done: false };
+          }
+        }
+      }
+      const value = this.slice(start, length);
+      start = length;
+      return { value, done: false };
+    };
+    return Iterator.from({ next });
+  },
+);

--- a/TypedArray.ts
+++ b/TypedArray.ts
@@ -5,10 +5,10 @@ declare global {
     readonly length: number;
     [index: number]: T;
   }
-  interface TypedArrayConstructor {
-    readonly prototype: TypedArray<unknown>;
+  interface TypedArrayConstructor<R extends TypedArray<T> = never, T = never> {
+    readonly prototype: TypedArray<T>;
     readonly BYTES_PER_ELEMENT: number;
-    from<T>(arrayLike: Iterable<T>): TypedArray<T>;
+    from(arrayLike: Iterable<T>): R;
   }
 
   interface Int8Array extends TypedArray<number> {}
@@ -23,20 +23,31 @@ declare global {
   interface BigInt64Array extends TypedArray<bigint> {}
   interface BigUint64Array extends TypedArray<bigint> {}
 
-  interface Int8ArrayConstructor extends TypedArrayConstructor {}
-  interface Uint8ArrayConstructor extends TypedArrayConstructor {}
-  interface Uint8ClampedArrayConstructor extends TypedArrayConstructor {}
-  interface Int16ArrayConstructor extends TypedArrayConstructor {}
-  interface Uint16ArrayConstructor extends TypedArrayConstructor {}
-  interface Int32ArrayConstructor extends TypedArrayConstructor {}
-  interface Uint32ArrayConstructor extends TypedArrayConstructor {}
-  interface Float32ArrayConstructor extends TypedArrayConstructor {}
-  interface Float64ArrayConstructor extends TypedArrayConstructor {}
-  interface BigInt64ArrayConstructor extends TypedArrayConstructor {
+  interface Int8ArrayConstructor
+    extends TypedArrayConstructor<Int8Array, number> {}
+  interface Uint8ArrayConstructor
+    extends TypedArrayConstructor<Uint8Array, number> {}
+  interface Uint8ClampedArrayConstructor
+    extends TypedArrayConstructor<Uint8Array, number> {}
+  interface Int16ArrayConstructor
+    extends TypedArrayConstructor<Int16Array, number> {}
+  interface Uint16ArrayConstructor
+    extends TypedArrayConstructor<Uint16Array, number> {}
+  interface Int32ArrayConstructor
+    extends TypedArrayConstructor<Int32Array, number> {}
+  interface Uint32ArrayConstructor
+    extends TypedArrayConstructor<Uint32Array, number> {}
+  interface Float32ArrayConstructor
+    extends TypedArrayConstructor<Float32Array, number> {}
+  interface Float64ArrayConstructor
+    extends TypedArrayConstructor<Float64Array, number> {}
+  interface BigInt64ArrayConstructor
+    extends TypedArrayConstructor<BigInt64Array, bigint> {
     // see https://github.com/microsoft/TypeScript/issues/45198
     from(arrayLike: Iterable<bigint>): BigInt64Array;
   }
-  interface BigUint64ArrayConstructor extends TypedArrayConstructor {
+  interface BigUint64ArrayConstructor
+    extends TypedArrayConstructor<BigUint64Array, bigint> {
     // see https://github.com/microsoft/TypeScript/issues/45198
     from(arrayLike: Iterable<bigint>): BigUint64Array;
   }

--- a/TypedArray/$.build.ts
+++ b/TypedArray/$.build.ts
@@ -1,63 +1,22 @@
-import TypedArray from "💰/TypedArray.ts";
-
 import $ from "💰/$.ts";
 import "💰/$/build.ts";
+import "💰/Object/$.defineDataProperty.ts";
 
-function value(
-  this: Int8ArrayConstructor,
-  generate: () => Iterable<number>,
-): Int8Array;
-function value(
-  this: Uint8ArrayConstructor,
-  generate: () => Iterable<number>,
-): Uint8Array;
-function value(
-  this: Uint8ClampedArrayConstructor,
-  generate: () => Iterable<number>,
-): Uint8ClampedArray;
-function value(
-  this: Int16ArrayConstructor,
-  generate: () => Iterable<number>,
-): Int16Array;
-function value(
-  this: Uint16ArrayConstructor,
-  generate: () => Iterable<number>,
-): Uint16Array;
-function value(
-  this: Int32ArrayConstructor,
-  generate: () => Iterable<number>,
-): Int32Array;
-function value(
-  this: Uint32ArrayConstructor,
-  generate: () => Iterable<number>,
-): Uint32Array;
-function value(
-  this: Float32ArrayConstructor,
-  generate: () => Iterable<number>,
-): Float32Array;
-function value(
-  this: Float64ArrayConstructor,
-  generate: () => Iterable<number>,
-): Float64Array;
-function value(
-  this: BigInt64ArrayConstructor,
-  generate: () => Iterable<bigint>,
-): BigInt64Array;
-function value(
-  this: BigUint64ArrayConstructor,
-  generate: () => Iterable<bigint>,
-): BigUint64Array;
-function value<T>(
-  this: TypedArrayConstructor,
-  generate: () => Iterable<T>,
-): TypedArray<T> {
-  return this.from(generate());
-}
+import TypedArray from "💰/TypedArray.ts";
 
 declare global {
-  interface TypedArrayConstructor {
-    [$.build]: typeof value;
+  interface TypedArrayConstructor<R, T> {
+    [$.build](generate: () => Iterable<T>): R;
   }
 }
 
-Object.defineProperty(TypedArray, $.build, { value });
+Object[$.defineDataProperty](
+  TypedArray,
+  $.build,
+  function value<R extends TypedArray<T>, T>(
+    this: TypedArrayConstructor<R, T>,
+    generate: () => Iterable<T>,
+  ): R {
+    return this.from(generate());
+  },
+);

--- a/WeakMap/$.build.ts
+++ b/WeakMap/$.build.ts
@@ -1,16 +1,19 @@
 import $ from "💰/$.ts";
 import "💰/$/build.ts";
-
-function value<K extends NonNullable<unknown>, V>(
-  generate: () => Iterable<readonly [K, V]>,
-): WeakMap<K, V> {
-  return new WeakMap(generate());
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface WeakMapConstructor {
-    [$.build]: typeof value;
+    [$.build]<K extends NonNullable<unknown>, V>(
+      generate: () => Iterable<readonly [K, V]>,
+    ): WeakMap<K, V>;
   }
 }
 
-Object.defineProperty(WeakMap, $.build, { value });
+Object[$.defineDataProperty](
+  WeakMap,
+  $.build,
+  function (generate) {
+    return new WeakMap(generate());
+  },
+);

--- a/WeakSet/$.build.ts
+++ b/WeakSet/$.build.ts
@@ -1,16 +1,19 @@
 import $ from "💰/$.ts";
 import "💰/$/build.ts";
-
-function value<T extends NonNullable<unknown>>(
-  generate: () => Iterable<T>,
-): WeakSet<T> {
-  return new WeakSet(generate());
-}
+import "💰/Object/$.defineDataProperty.ts";
 
 declare global {
   interface WeakSetConstructor {
-    [$.build]: typeof value;
+    [$.build]<T extends NonNullable<unknown>>(
+      generate: () => Iterable<T>,
+    ): WeakSet<T>;
   }
 }
 
-Object.defineProperty(WeakSet, $.build, { value });
+Object[$.defineDataProperty](
+  WeakSet,
+  $.build,
+  function (generate) {
+    return new WeakSet(generate());
+  },
+);


### PR DESCRIPTION
Changes augmented methods from TypeScript _properties_ to TypeScript _methods_ to avoid contravarient issues (see https://stackoverflow.com/a/55992840/3255152).

To do so, a new `$.defineDataProperty` method is defined on `Object`. This method can be used to create non-enumerable data properties (default) or read-only data properties.

To further simplify things, `TypedArrayConstructor` now uses generics:
- `R`: ReturnType (e.g. `Int8Array`)
- `T`: Type of items (e.g. `number`)

BREAKING CHANGE: to avoid prototype pollution issues, progression methods no longer receive an `options` bag for `step` but takes `step` directly as an optional, second argument to `$.through()` or `$.to()`.